### PR TITLE
docs: asset CRUD + UPLOAD broll type (SWE-3342)

### DIFF
--- a/api-reference/endpoint/assets.create.mdx
+++ b/api-reference/endpoint/assets.create.mdx
@@ -1,0 +1,51 @@
+---
+title: "Upload Asset"
+openapi: post /assets
+sidebarTitle: "/assets"
+description: "Upload an image or video asset via URL for use as B-roll"
+---
+
+Upload an image or video by providing a publicly accessible URL. The asset is downloaded and processed asynchronously.
+
+## Usage Flow
+
+1. Call `POST /assets` with the asset URL, name, and type
+2. Receive the asset ID with `status: PROCESSING`
+3. Poll `GET /assets/{id}` until `status` is `READY`
+4. Use the asset ID in `POST /videos` with `broll.type: UPLOAD`
+
+## Example
+
+```bash
+# 1. Upload
+curl -X POST https://api.argil.ai/v1/assets \
+  -H "Authorization: ApiKey YOUR_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "product-demo",
+    "type": "VIDEO",
+    "url": "https://example.com/demo.mp4"
+  }'
+
+# 2. Poll until ready
+curl https://api.argil.ai/v1/assets/ASSET_ID \
+  -H "Authorization: ApiKey YOUR_KEY"
+
+# 3. Use as B-roll in a video
+curl -X POST https://api.argil.ai/v1/videos \
+  -H "Authorization: ApiKey YOUR_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "avatarId": "...",
+    "voiceId": "...",
+    "moments": [{
+      "transcript": "Check out our product",
+      "broll": {
+        "type": "UPLOAD",
+        "assetId": "ASSET_ID"
+      }
+    }]
+  }'
+```
+
+---

--- a/api-reference/endpoint/assets.create.mdx
+++ b/api-reference/endpoint/assets.create.mdx
@@ -36,10 +36,12 @@ curl -X POST https://api.argil.ai/v1/videos \
   -H "Authorization: ApiKey YOUR_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "avatarId": "...",
-    "voiceId": "...",
+    "name": "my-video",
+    "type": "moments",
     "moments": [{
       "transcript": "Check out our product",
+      "avatarId": "...",
+      "voiceId": "...",
       "broll": {
         "type": "UPLOAD",
         "assetId": "ASSET_ID"

--- a/api-reference/endpoint/assets.delete.mdx
+++ b/api-reference/endpoint/assets.delete.mdx
@@ -1,0 +1,10 @@
+---
+title: "Delete Asset"
+openapi: delete /assets/{id}
+sidebarTitle: "/assets/{id}"
+description: "Delete an uploaded asset"
+---
+
+Soft-deletes an asset. The asset is removed from your library but existing videos that use it will continue to render normally.
+
+---

--- a/api-reference/endpoint/assets.get.mdx
+++ b/api-reference/endpoint/assets.get.mdx
@@ -1,14 +1,22 @@
 ---
-title: "Get an Asset by id"
+title: "Get Asset"
 openapi: get /assets/{id}
 sidebarTitle: "/assets/{id}"
+description: "Get an asset by ID with its current processing status"
 ---
 
-Returns an asset identified by its id from your library that can be used in your videos.
+Returns an asset with its current processing status and metadata. Use this endpoint to poll for processing completion after uploading an asset.
 
-## Audio Assets
+## Status Lifecycle
 
-Audio assets from this endpoint can be used as background music in your videos. When creating a video, you can reference an audio asset's ID in the `backgroundMusic` parameter to add it as background music. See the [Create Video endpoint](/api-reference/endpoint/videos.create) for more details.
+```
+POST /assets → PROCESSING → READY (or FAILED)
+```
 
+| Status | Description |
+|--------|-------------|
+| `PROCESSING` | Asset is being downloaded and processed |
+| `READY` | Asset is ready to use as B-roll |
+| `FAILED` | Processing failed — upload a new asset |
 
 ---

--- a/api-reference/endpoint/assets.list.mdx
+++ b/api-reference/endpoint/assets.list.mdx
@@ -2,32 +2,39 @@
 title: "List Assets"
 openapi: get /assets
 sidebarTitle: "/assets"
-description: "Get a paginated list of assets from your library"
+description: "Get a list of assets from your library"
 ---
 
-Returns a paginated list of assets from your library. By default, only assets with status `READY` are returned.
+Returns an array of assets from your library. Supports filtering by type and status, with pagination via query parameters.
+
+Pagination metadata is returned in response headers:
+
+| Header | Description |
+|--------|-------------|
+| `X-Total-Count` | Total number of assets matching the filters |
+| `X-Page` | Current page number |
+| `X-Page-Size` | Number of items per page |
+| `X-Total-Pages` | Total number of pages |
 
 ## Asset Types
 
 | Type | Description |
 |------|-------------|
-| `AUDIO` | Audio files for background music (system library, read-only) |
+| `AUDIO` | Audio files for background music (system library) |
 | `IMAGE` | Uploaded images for use as B-roll |
 | `VIDEO` | Uploaded videos for use as B-roll |
 
-## Filtering
-
-Use query parameters to filter by type and status:
+## Examples
 
 ```bash
+# All assets (default: READY status)
+GET /assets
+
 # Only video assets
 GET /assets?type=VIDEO
 
-# Images and videos
-GET /assets?type=IMAGE&type=VIDEO
-
-# Assets still processing
-GET /assets?status=PROCESSING
+# Images and videos, page 2
+GET /assets?type=IMAGE&type=VIDEO&page=2&pageSize=10
 ```
 
 ---

--- a/api-reference/endpoint/assets.list.mdx
+++ b/api-reference/endpoint/assets.list.mdx
@@ -2,14 +2,32 @@
 title: "List Assets"
 openapi: get /assets
 sidebarTitle: "/assets"
-description: "Get a list of available assets from your library"
+description: "Get a paginated list of assets from your library"
 ---
 
-Returns an array of assets from your library that can be used in your videos.
+Returns a paginated list of assets from your library. By default, only assets with status `READY` are returned.
 
-## Audio Assets
+## Asset Types
 
-Audio assets from this endpoint can be used as background music in your videos. When creating a video, you can reference an audio asset's ID in the `backgroundMusic` parameter to add it as background music. See the [Create Video endpoint](/api-reference/endpoint/videos.create) for more details.
+| Type | Description |
+|------|-------------|
+| `AUDIO` | Audio files for background music (system library, read-only) |
+| `IMAGE` | Uploaded images for use as B-roll |
+| `VIDEO` | Uploaded videos for use as B-roll |
 
+## Filtering
+
+Use query parameters to filter by type and status:
+
+```bash
+# Only video assets
+GET /assets?type=VIDEO
+
+# Images and videos
+GET /assets?type=IMAGE&type=VIDEO
+
+# Assets still processing
+GET /assets?status=PROCESSING
+```
 
 ---

--- a/docs.json
+++ b/docs.json
@@ -172,7 +172,9 @@
             "group": "Assets",
             "pages": [
               "api-reference/endpoint/assets.list",
-              "api-reference/endpoint/assets.get"
+              "api-reference/endpoint/assets.create",
+              "api-reference/endpoint/assets.get",
+              "api-reference/endpoint/assets.delete"
             ]
           },
           {

--- a/openapi.yml
+++ b/openapi.yml
@@ -539,24 +539,30 @@ paths:
             default: 20
       responses:
         200:
-          description: A paginated list of assets
+          description: An array of assets. Pagination metadata is in response headers.
+          headers:
+            X-Total-Count:
+              schema:
+                type: integer
+              description: Total number of assets matching the filters
+            X-Page:
+              schema:
+                type: integer
+              description: Current page number
+            X-Page-Size:
+              schema:
+                type: integer
+              description: Number of items per page
+            X-Total-Pages:
+              schema:
+                type: integer
+              description: Total number of pages
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  items:
-                    type: array
-                    items:
-                      $ref: "#/components/schemas/Asset"
-                  totalItems:
-                    type: integer
-                  currentPage:
-                    type: integer
-                  totalPages:
-                    type: integer
-                  itemsPerPage:
-                    type: integer
+                type: array
+                items:
+                  $ref: "#/components/schemas/Asset"
         400:
           description: Unexpected error
           content:

--- a/openapi.yml
+++ b/openapi.yml
@@ -500,41 +500,182 @@ paths:
                 $ref: "#/components/schemas/Error"
   /assets:
     get:
-      summary: List audio assets
-      description: Returns an array of audio assets available for the user
+      summary: List assets
+      description: Returns a paginated list of assets from your library. Includes user-uploaded assets and system assets (e.g. music library).
+      parameters:
+        - name: type
+          in: query
+          description: "Filter by asset type. Can be specified multiple times (e.g. `?type=VIDEO&type=IMAGE`). Omit to return all types."
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+              enum: [AUDIO, IMAGE, VIDEO]
+        - name: status
+          in: query
+          description: "Filter by processing status. Default: READY."
+          required: false
+          schema:
+            type: string
+            enum: [PROCESSING, READY, FAILED]
+            default: READY
+        - name: page
+          in: query
+          description: Page number
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+        - name: pageSize
+          in: query
+          description: Number of items per page
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 20
       responses:
         200:
-          description: An array of audio assets
+          description: A paginated list of assets
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/Asset"
+                type: object
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Asset"
+                  totalItems:
+                    type: integer
+                  currentPage:
+                    type: integer
+                  totalPages:
+                    type: integer
+                  itemsPerPage:
+                    type: integer
         400:
           description: Unexpected error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+    post:
+      summary: Upload an asset
+      description: |
+        Upload an image or video asset by providing a publicly accessible URL. The asset is downloaded and processed asynchronously.
+
+        Poll `GET /assets/{id}` until `status` is `READY` before using the asset as B-roll in a video.
+
+        **Size limits:** 50 MB for images, 2 GB for videos.
+
+        **Accepted formats:** JPEG, PNG, GIF, WEBP, AVIF for images. MP4, MOV for videos.
+
+        **Concurrent limit:** Maximum 5 assets processing at a time per workspace.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+                - type
+                - url
+              properties:
+                name:
+                  type: string
+                  description: "Display name for the asset"
+                  minLength: 1
+                  maxLength: 256
+                type:
+                  type: string
+                  enum: [IMAGE, VIDEO]
+                  description: "Asset type. Audio upload is not supported."
+                url:
+                  type: string
+                  format: uri
+                  description: "Publicly accessible URL to download the asset from"
+              additionalProperties: false
+            example:
+              name: "my-broll-clip"
+              type: "VIDEO"
+              url: "https://example.com/clip.mp4"
+      responses:
+        201:
+          description: Asset created and processing started
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Asset"
+        200:
+          description: Duplicate asset found — existing asset returned
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Asset"
+        400:
+          description: "Validation error (unsupported format, file too large, URL unreachable)"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        429:
+          description: "Too many assets processing concurrently (max 5)"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
   /assets/{id}:
     get:
-      summary: Get an Asset by id
-      description: Returns a single Asset identified by its id
+      summary: Get an asset by ID
+      description: Returns a single asset with its current processing status and metadata.
       parameters:
         - name: id
           in: path
           required: true
           schema:
             type: string
-            description: The id of the Asset to retrieve
+            format: uuid
+            description: The ID of the asset to retrieve
       responses:
         200:
-          description: Detailed information about the Asset
+          description: Asset details
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/Asset"
+        404:
+          description: Asset not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    delete:
+      summary: Delete an asset
+      description: |
+        Soft-deletes an asset. The asset is hidden from listings but existing videos using it continue to render.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        200:
+          description: Asset deleted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "Asset deleted"
         404:
           description: Asset not found
           content:
@@ -1290,6 +1431,27 @@ components:
               allOf:
                 - $ref: '#/components/schemas/Zoom'
           additionalProperties: false
+        - type: object
+          title: UPLOAD
+          description: "Use a previously uploaded asset as B-roll. The asset must have status READY and be of type IMAGE or VIDEO. Upload assets via `POST /assets`."
+          required:
+            - type
+            - assetId
+          properties:
+            type:
+              type: string
+              enum: [UPLOAD]
+            assetId:
+              type: string
+              format: uuid
+              description: "ID of the uploaded asset (from `POST /assets`). Must be READY status and IMAGE or VIDEO type."
+            layout:
+              $ref: '#/components/schemas/BrollLayout'
+            zoom:
+              description: "Zoom applied to this B-roll."
+              allOf:
+                - $ref: '#/components/schemas/Zoom'
+          additionalProperties: false
       discriminator:
         propertyName: type
     Zoom:
@@ -1341,12 +1503,25 @@ components:
           format: uuid
         name:
           type: string
+          nullable: true
         type:
           type: string
-          enum: [AUDIO]
+          enum: [AUDIO, IMAGE, VIDEO]
+        status:
+          type: string
+          enum: [PROCESSING, READY, FAILED]
+          description: "Processing status. Poll until READY before using as B-roll."
         fileUrl:
           type: string
-          description: "URL to access the asset"
+          nullable: true
+          description: "URL to access the asset. Null while processing."
+        thumbnailUrl:
+          type: string
+          nullable: true
+          description: "URL to a thumbnail image. Null while processing."
+        createdAt:
+          type: string
+          format: date-time
     SubtitleStyle:
       type: object
       properties:


### PR DESCRIPTION
## Summary

Updates API documentation for custom media upload as B-roll (SWE-3342).

- **POST /assets**: new endpoint — upload image/video via URL
- **DELETE /assets/{id}**: new endpoint — soft-delete
- **GET /assets**: enhanced — paginated, filterable by type/status, all asset types
- **GET /assets/{id}**: enhanced — includes status, thumbnailUrl, createdAt
- **Asset schema**: expanded (AUDIO/IMAGE/VIDEO types, PROCESSING/READY/FAILED status)
- **UPLOAD broll type**: added to MomentBroll in video creation

Companion to argildotai/app#4422.

🤖 Generated with [Claude Code](https://claude.com/claude-code)