### PR TITLE
docs: add duration field to GET /videos/{id} response

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -992,6 +992,10 @@ components:
         status:
           type: string
           description: "Can be either `IDLE`, `GENERATING_AUDIO`, `GENERATING_VIDEO`, `DONE` or `FAILED`."
+        duration:
+          type: number
+          nullable: true
+          description: "Total video duration in seconds. `null` when audio hasn't been generated yet."
         moments:
           type: array
           description: "An array of Moment items, each representing a portion of the complete video."


### PR DESCRIPTION
## Summary
- Add `duration` (number | null) to the video response schema in openapi.yml
- Duration is the total video length in seconds, `null` when audio hasn't been generated yet
- Reflects app change from argildotai/app#4417 (SWE-3338)

## Test plan
- [ ] Verify the docs render correctly with the new field on Mintlify

🤖 Generated with [Claude Code](https://claude.com/claude-code)