### PR TITLE
docs: fix transcript char limit (250 → 500) in openapi.yml

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -1151,7 +1151,7 @@ components:
             properties:
               transcript:
                 type: string
-                description: "A portion of the complete transcript. Current limit: 250 characters."
+                description: "A portion of the complete transcript. Current limit: 500 characters."
               avatarId:
                 type: string
                 description: "The id of the avatar to be used for this moment."
@@ -1221,7 +1221,7 @@ components:
             properties:
               transcript:
                 type: string
-                description: "A portion of the complete transcript. Mutually exclusive with `audioUrl` — provide one or the other, not both. Current limit: 250 characters"
+                description: "A portion of the complete transcript. Mutually exclusive with `audioUrl` — provide one or the other, not both. Current limit: 500 characters"
               audioUrl:
                 type: string
                 description: "URL to an audio file for this moment, bypassing TTS generation. Mutually exclusive with `transcript` — provide one or the other, not both. Max duration: 40 seconds"


### PR DESCRIPTION
## Summary

Fixes two stale descriptions in `openapi.yml` that told API consumers the transcript limit was 250 characters.

- The doc has said "250" since its creation (2024-09-16) — a value that **never matched** the code.
- `MAX_TRANSCRIPT_LENGTH = 500` in `app/api/src/apis/public/rest/shared/config/constants.ts` is the source of truth.
- The limit reached 500 on 2025-07-29 (commit `b791bdf942`); before that it was 175 → 350, never 250.

**Changes:** lines 1154 and 1224 of `openapi.yml` updated from 250 → 500.  
**Not changed:** audio limit (40s) was already correct.

Closes [SWE-3479](https://linear.app/argildotai/issue/SWE-3479/docs-openapiyml-says-transcript-limit-is-250-chars-but-code-allows-500)